### PR TITLE
Stop filtering out empty editors picks.

### DIFF
--- a/src/main/scala/com/gu/contentapi/Lambda.scala
+++ b/src/main/scala/com/gu/contentapi/Lambda.scala
@@ -21,8 +21,7 @@ class Lambda
     for {
       front <- facia.fronts
       collections <- facia.collections(front)(config)
-      editorsPick <- EditorsPick(front, collections)
-      notification = Notification.create(editorsPick)
+      notification = Notification.create(EditorsPick(front, collections))
     } yield {
       sns.publish(config.aws.topicArn, Json.stringify(Json.toJson(notification))) match {
         case Success(_) => println(s"Successfully published editors picks for front: ${notification.body.id}")

--- a/src/main/scala/com/gu/contentapi/models/EditorsPick.scala
+++ b/src/main/scala/com/gu/contentapi/models/EditorsPick.scala
@@ -14,6 +14,5 @@ object EditorsPick {
 
     Option(first25ContentItemsFromAllCollections)
       .map(item => EditorsPick(front, item))
-      .filter(_.contentItems.nonEmpty) // we filter out collections that are empty so that in the event of a problem we don't overwrite them in Elasticsearch - discuss whether this is good or bad.
   }
 }

--- a/src/main/scala/com/gu/contentapi/models/EditorsPick.scala
+++ b/src/main/scala/com/gu/contentapi/models/EditorsPick.scala
@@ -5,14 +5,13 @@ import play.api.libs.json.{ JsArray, JsValue }
 case class EditorsPick(front: String, contentItems: Seq[JsValue])
 
 object EditorsPick {
-  def apply(front: String, collections: JsArray): Option[EditorsPick] = {
+  def apply(front: String, collections: JsArray): EditorsPick = {
 
     val first25ContentItemsFromAllCollections: Seq[JsValue] =
       collections.value
         .flatMap(c => (c \ "content").asOpt[JsArray].map(_.value))
         .flatten.take(25)
 
-    Option(first25ContentItemsFromAllCollections)
-      .map(item => EditorsPick(front, item))
+    EditorsPick(front, first25ContentItemsFromAllCollections)
   }
 }

--- a/src/test/scala/com/gu/contentapi/models/EditorsPickSpec.scala
+++ b/src/test/scala/com/gu/contentapi/models/EditorsPickSpec.scala
@@ -7,14 +7,6 @@ import scala.io.Source._
 
 class EditorsPickSpec extends FlatSpec with Matchers {
 
-  it should "not create an editors pick if collections are empty" in {
-    val front = "uk"
-    val collections: JsArray = JsArray(Nil)
-    val editorsPick = EditorsPick(front, collections)
-
-    editorsPick should be(None)
-  }
-
   it should "create an editors pick with the correct number of content items" in {
     val front = "uk"
     val collections = (Json.parse(fromFile("src/test/resources/uk-collections.json").mkString) \ "collections").as[JsArray]

--- a/src/test/scala/com/gu/contentapi/models/EditorsPickSpec.scala
+++ b/src/test/scala/com/gu/contentapi/models/EditorsPickSpec.scala
@@ -13,11 +13,10 @@ class EditorsPickSpec extends FlatSpec with Matchers {
     val editorsPick = EditorsPick(front, collections)
     val expectedContentItems = Json.parse(fromFile("src/test/resources/uk-expected-content-items.json").mkString).as[JsArray]
 
-    editorsPick should not be (None)
-    editorsPick.foreach(_.front should be("uk"))
+    editorsPick.front should be("uk")
 
-    editorsPick.foreach(_.contentItems.size should be(25))
-    editorsPick.map(_.contentItems == expectedContentItems.value) should be(Some(true))
+    editorsPick.contentItems.size should be(25)
+    (editorsPick.contentItems == expectedContentItems.value) should be(true)
   }
 
 }


### PR DESCRIPTION
We have a sanity test which checks if editors picks are empty on the main fronts which alerts in the event of any problems.
I think this is a valuable systems test and it failing loudly in this case is of more value than leaving stale editors picks in place without us noticing.
