### PR TITLE
Bump memory and add an alarm to SNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,11 @@ AWS Lambda to upload editors picks to the Content API.
 The editors-picks-uploader is responsible for periodically (every 5 minutes) uploading editors picks to the content API.
 It does this by hitting `http://api.nextgen.guardianapps.co.uk/PATH/lite.json` where PATH is a front obtained from the 
 facia client, taking the top 25 items (regardless of which collection) and sending them to be indexed by CAPI.
+
+# Alarms
+If editors picks data is not updating in capi then it's because either:
+1. This lambda is not publishing to SNS. There is a cloudwatch alarm created by this stack for alerting when no messages are published for 10mins.
+2. Porter is not reading from its SQS queue. There is a cloudwatch alarm in the Porter stack for alerting when messages on the queue are older than 20mins.
+
+In both cases you can check the status of these metrics from the cloudwatch console.
+

--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -12,6 +12,9 @@ Parameters:
   NextgenApiUrl:
     Description: 'URL of nextgen api'
     Type: String
+  AlarmTopic:
+    Description: The SNS topic that urgent CloudWatch alarms publish to
+    Type: String
 
 Resources:
   RootRole:
@@ -55,6 +58,25 @@ Resources:
     Properties:
       TopicName: !Sub content-api-notifications-shuttlerun-${Stage}
 
+  SNSAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: Alarm when no messages for 10mins
+      Namespace: AWS/SNS
+      MetricName: NumberOfMessagesPublished
+      Dimensions:
+        - Name: TopicName
+          Value: !GetAtt NotificationsTopic.TopicName
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 2
+      Threshold: 0
+      ComparisonOperator: LessThanOrEqualToThreshold
+      AlarmActions:
+        - Ref: AlarmTopic
+      InsufficientDataActions:
+        - Ref: AlarmTopic
+
   Lambda:
     Type : AWS::Lambda::Function
     Properties:
@@ -71,7 +93,7 @@ Resources:
         S3Key: !Sub content-api/${Stage}/editors-picks-uploader/editors-picks-uploader.zip
       Description: 'Editors picks uploader - retrieves and uploads editors picks for consumption by the Content API'
       Handler : com.gu.contentapi.Lambda::handleRequest
-      MemorySize : 256
+      MemorySize : 320
       Role: !GetAtt RootRole.Arn
       Runtime : java8
       Timeout : 180


### PR DESCRIPTION
This lambda seems to variously fail with out-of-memory or timeouts since the upgrade to scala 2.12.
Bumping the memory fixes this.
I've also added an alarm to the SNS topic so we are alerted when no messages are sent for 2 consecutive periods of 5 mins

@gtrufitt 