### PR TITLE
Replace deprecated `bucket` riff-raff parameter

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -8,7 +8,7 @@ deployments:
     type: aws-lambda
     parameters:
       fileName: editors-picks-uploader.zip
-      bucket: content-api-dist
+      bucketSsmLookup: true
       functions:
         CODE: 
           name: editors-picks-uploader-CODE


### PR DESCRIPTION
The `bucket` parameter in riff-raff.yaml has been deprecated in favour of `bucketSsmLookup`.  This causes Riffraff to look up the destination bucket from a parameter in the AWS account's SSM parameter store instead of being hard-coded.  We are currently getting deprecation warnings when deploying this project in riffraff, and merging this PR should fix that by replacing the deprecated parameter with the new one.