### PR TITLE
Bump dependencies

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -13,6 +13,6 @@ jobs:
       DEBUG: true
       ORG: guardian-capi
       SKIP_NODE: true
-      JAVA_VERSION: 8
+      JAVA_VERSION: 11
     secrets:
        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization  := "com.gu"
 description   := "AWS Lambda uploading editors picks from Facia to CAPI"
 scalacOptions += "-deprecation"
 scalaVersion  := "2.13.10"
-scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-release", "8", "-Xfatal-warnings")
+scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-Xfatal-warnings")
 name := "editors-picks-uploader"
 
 lazy val editorsPicksUploader = (project in file(".")).enablePlugins(JavaAppPackaging, RiffRaffArtifact)
@@ -36,6 +36,6 @@ riffRaffUploadManifestBucket := Option("riffraff-builds")
 
 initialize := {
   val _ = initialize.value
-  assert(sys.props("java.specification.version") == "1.8",
-    "Java 8 is required for this project.")
+  assert(sys.props("java.specification.version") == "11",
+    "Java 11 is required for this project.")
 }

--- a/build.sbt
+++ b/build.sbt
@@ -1,31 +1,36 @@
 organization  := "com.gu"
 description   := "AWS Lambda uploading editors picks from Facia to CAPI"
 scalacOptions += "-deprecation"
-scalaVersion  := "2.12.6"
-scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-target:jvm-1.8", "-Xfatal-warnings")
+scalaVersion  := "2.13.10"
+scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-release", "8", "-Xfatal-warnings")
 name := "editors-picks-uploader"
 
 lazy val editorsPicksUploader = (project in file(".")).enablePlugins(JavaAppPackaging, RiffRaffArtifact)
 
-val AwsSdkVersion = "1.11.335"
+val AwsSdkVersion = "1.12.261"
 
 libraryDependencies ++= Seq(
-  "com.amazonaws" % "aws-lambda-java-core" % "1.1.0",
+  "com.amazonaws" % "aws-lambda-java-core" % "1.2.2",
   "com.amazonaws" % "aws-java-sdk-sts" % AwsSdkVersion,
   "com.amazonaws" % "aws-java-sdk-s3" % AwsSdkVersion,
   "com.amazonaws" % "aws-java-sdk-sns" % AwsSdkVersion,
-  "com.gu" %% "facia-json-play26" % "2.6.0",
-  "com.typesafe.play" %% "play-json-joda" % "2.6.9",
-  "com.squareup.okhttp" % "okhttp" % "2.5.0",
-  "org.scalatest" %% "scalatest" % "3.0.5" % "test"
+  "com.gu" %% "facia-json-play27" % "4.0.5",
+  "com.typesafe.play" %% "play-json-joda" % "2.9.4",
+  "com.squareup.okhttp" % "okhttp" % "2.7.5",
+  "org.scalatest" %% "scalatest" % "3.2.15" % "test"
 )
 
-topLevelDirectory in Universal := None
-packageName in Universal := normalizedName.value
+dependencyOverrides ++=  Seq(
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.14.2",
+  "com.fasterxml.jackson.dataformat"  % "jackson-dataformat-cbor" % "2.14.2"
+)
+
+Universal / topLevelDirectory := None
+Universal / packageName  := normalizedName.value
 
 riffRaffManifestProjectName := s"Content Platforms::editors-picks-uploader-lambda"
 riffRaffPackageName := "editors-picks-uploader"
-riffRaffPackageType := (packageBin in Universal).value
+riffRaffPackageType := (Universal / packageBin).value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")
 

--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -95,5 +95,5 @@ Resources:
       Handler : com.gu.contentapi.Lambda::handleRequest
       MemorySize : 320
       Role: !GetAtt RootRole.Arn
-      Runtime : java8
+      Runtime : java11
       Timeout : 180

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.12
+sbt.version=1.7.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.4")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.12")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.6")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.4")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.4")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.6")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
 

--- a/src/main/scala/com/gu/contentapi/models/EditorsPick.scala
+++ b/src/main/scala/com/gu/contentapi/models/EditorsPick.scala
@@ -10,7 +10,7 @@ object EditorsPick {
     val first25ContentItemsFromAllCollections: Seq[JsValue] =
       collections.value
         .flatMap(c => (c \ "content").asOpt[JsArray].map(_.value))
-        .flatten.take(25)
+        .flatten.take(25).toSeq
 
     EditorsPick(front, first25ContentItemsFromAllCollections)
   }

--- a/src/test/scala/com/gu/contentapi/models/EditorsPickSpec.scala
+++ b/src/test/scala/com/gu/contentapi/models/EditorsPickSpec.scala
@@ -1,11 +1,12 @@
 package com.gu.contentapi.models
 
-import org.scalatest.{ FlatSpec, Matchers }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.{ JsArray, Json }
 
 import scala.io.Source._
 
-class EditorsPickSpec extends FlatSpec with Matchers {
+class EditorsPickSpec extends AnyFlatSpec with Matchers {
 
   it should "create an editors pick with the correct number of content items" in {
     val front = "uk"

--- a/src/test/scala/com/gu/contentapi/models/NotificationSpec.scala
+++ b/src/test/scala/com/gu/contentapi/models/NotificationSpec.scala
@@ -1,10 +1,11 @@
 package com.gu.contentapi.models
 
 import org.joda.time.{ DateTime, DateTimeUtils }
-import org.scalatest.{ FlatSpec, Matchers }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.{ JsArray }
 
-class NotificationSpec extends FlatSpec with Matchers {
+class NotificationSpec extends AnyFlatSpec with Matchers {
 
   it should "Create a notification" in {
     val now = new DateTime


### PR DESCRIPTION
## What does this change?

Upgrades dependencies to bring down Snyk vulnerabilities.

- SBT 0.13.x to 1.7.3
- Scala 2.12.x to 2.13.10
- Java 8 to Java 11
- Other dependency bumps

And brings Snyk vulnerabilities down to 0:
https://app.snyk.io/org/guardian-people/project/bfd58275-1490-4db3-ac6b-24fedb705a2e/history/7d5243ba-d198-4678-b0cd-90a84a7d5288

## How to test

Tested in CODE:
 
<img width="1437" alt="Screenshot 2023-03-30 at 15 43 33" src="https://user-images.githubusercontent.com/74187452/228873609-bd60f66c-d35e-45f0-8d23-a4958b63cc26.png">


