### PR TITLE
Migrate build to GHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,49 @@
+name: Build editors-picks-uploader
+
+on:
+  push:
+    branches: [ "**" ]
+  workflow_dispatch: {}
+
+jobs:
+  editors-picks-uploader:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      checks: write
+      issues: read
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: corretto
+          java-version: 11
+          cache: sbt
+
+      - name: Build and test
+        env:
+          SBT_JUNIT_OUTPUT: ./junit-tests
+        run: sbt 'test;universal:packageBin'
+
+      - uses: EnricoMi/publish-unit-test-result-action@v1
+        if: always()  #runs even if there is a test failure
+        with:
+          files: junit-tests/*.xml
+
+      - uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          aws-region: eu-west-1
+          role-to-assume: ${{secrets.GU_RIFF_RAFF_ROLE_ARN}}
+
+      - uses: guardian/actions-riff-raff@v2
+        with:
+          configPath: riff-raff.yaml
+          projectName: Content Platforms::editors-picks-uploader-lambda
+          buildNumberOffset: 71
+          contentDirectories: |
+            editors-picks-uploader:
+              - target/universal/editors-picks-uploader.zip

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ scalaVersion  := "2.13.10"
 scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-Xfatal-warnings")
 name := "editors-picks-uploader"
 
-lazy val editorsPicksUploader = (project in file(".")).enablePlugins(JavaAppPackaging, RiffRaffArtifact)
+lazy val editorsPicksUploader = (project in file(".")).enablePlugins(JavaAppPackaging)
 
 val AwsSdkVersion = "1.12.261"
 
@@ -28,14 +28,11 @@ dependencyOverrides ++=  Seq(
 Universal / topLevelDirectory := None
 Universal / packageName  := normalizedName.value
 
-riffRaffManifestProjectName := s"Content Platforms::editors-picks-uploader-lambda"
-riffRaffPackageName := "editors-picks-uploader"
-riffRaffPackageType := (Universal / packageBin).value
-riffRaffUploadArtifactBucket := Option("riffraff-artifact")
-riffRaffUploadManifestBucket := Option("riffraff-builds")
-
 initialize := {
   val _ = initialize.value
   assert(sys.props("java.specification.version") == "11",
     "Java 11 is required for this project.")
 }
+
+
+Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-u", sys.env.getOrElse("SBT_JUNIT_OUTPUT", "junit"))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,5 @@
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.12")
-
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.6")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,6 @@
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.6")
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
+
+addDependencyTreePlugin
 


### PR DESCRIPTION
## What does this change?

This migrates the build process to Github Actions and removes the `riffraff-artifact` plugin.

## How to test

Tested in CODE. Activity and logs look fine.
<img width="1102" alt="Screenshot 2023-07-27 at 17 04 39" src="https://github.com/guardian/editors-picks-uploader/assets/74187452/0e7b8c8d-fc21-4e1a-95f2-8f3407156ff7">

## How can we measure success?

Everything should work as normal. Should build and deploy successfully.

