### PR TITLE
Update to fapi-client v4.0.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .DS_Store
 target/
 .idea*
+.bsp
+junit/
+

--- a/build.sbt
+++ b/build.sbt
@@ -14,10 +14,10 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-sts" % AwsSdkVersion,
   "com.amazonaws" % "aws-java-sdk-s3" % AwsSdkVersion,
   "com.amazonaws" % "aws-java-sdk-sns" % AwsSdkVersion,
-  "com.gu" %% "facia-json-play27" % "4.0.5",
+  "com.gu" %% "facia-json-play28" % "4.0.6",
   "com.typesafe.play" %% "play-json-joda" % "2.9.4",
   "com.squareup.okhttp" % "okhttp" % "2.7.5",
-  "org.scalatest" %% "scalatest" % "3.2.15" % "test"
+  "org.scalatest" %% "scalatest" % "3.2.15" % Test
 )
 
 dependencyOverrides ++=  Seq(


### PR DESCRIPTION
This is a small upgrade, catching up with the recent dependency updates of https://github.com/guardian/facia-scala-client/releases/tag/v4.0.6, before the more extensive update in https://github.com/guardian/facia-scala-client/pull/287 is introduced.

This update has already been tested in Ophan's PromotionPoller with https://github.com/guardian/ophan/pull/5540, successfully deployed to Prodution.

I've switched from `fapi-client-play27` to `fapi-client-play28` - the `editors-picks-uploader` is an AWS Lambda, it doesn't actually run the Play framework, so specifying a higher Play version doesn't really affect it! The `fapi-client` uses `play-json` to do its JSON-parsing (that's all that the `-play2x` suffix indicates), so we might as well use the latest version that's available (allowing `facia-scala-client` to drop support for `play27` at some future point).
