### PR TITLE
Fix jackson high vuln and bump facia and aws sdk version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       id-token: write
       contents: read
       checks: write
-      issues: read
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
           SBT_JUNIT_OUTPUT: ./junit-tests
         run: sbt 'test;universal:packageBin'
 
-      - uses: EnricoMi/publish-unit-test-result-action@v1
+      - uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()  #runs even if there is a test failure
         with:
           files: junit-tests/*.xml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           files: junit-tests/*.xml
 
-      - uses: aws-actions/configure-aws-credentials@v3
+      - uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-region: eu-west-1
           role-to-assume: ${{secrets.GU_RIFF_RAFF_ROLE_ARN}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           files: junit-tests/*.xml
 
-      - uses: aws-actions/configure-aws-credentials@v2
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: eu-west-1
           role-to-assume: ${{secrets.GU_RIFF_RAFF_ROLE_ARN}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,14 +34,11 @@ jobs:
         with:
           files: junit-tests/*.xml
 
-      - uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: eu-west-1
-          role-to-assume: ${{secrets.GU_RIFF_RAFF_ROLE_ARN}}
-
-      - uses: guardian/actions-riff-raff@v2
+      - uses: guardian/actions-riff-raff@v4
         with:
           configPath: riff-raff.yaml
+          roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
           projectName: Content Platforms::editors-picks-uploader-lambda
           buildNumberOffset: 71
           contentDirectories: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           files: junit-tests/*.xml
 
-      - uses: aws-actions/configure-aws-credentials@v1-node16
+      - uses: aws-actions/configure-aws-credentials@v3
         with:
           aws-region: eu-west-1
           role-to-assume: ${{secrets.GU_RIFF_RAFF_ROLE_ARN}}

--- a/build.sbt
+++ b/build.sbt
@@ -7,22 +7,22 @@ name := "editors-picks-uploader"
 
 lazy val editorsPicksUploader = (project in file(".")).enablePlugins(JavaAppPackaging)
 
-val AwsSdkVersion = "1.12.641"
+val AwsSdkVersion = "1.12.673"
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.2",
   "com.amazonaws" % "aws-java-sdk-sts" % AwsSdkVersion,
   "com.amazonaws" % "aws-java-sdk-s3" % AwsSdkVersion,
   "com.amazonaws" % "aws-java-sdk-sns" % AwsSdkVersion,
-  "com.gu" %% "facia-json-play27" % "4.0.5",
+  "com.gu" %% "facia-json-play30" % "9.0.0",
   "com.typesafe.play" %% "play-json-joda" % "2.9.4",
   "com.squareup.okhttp" % "okhttp" % "2.7.5",
   "org.scalatest" %% "scalatest" % "3.2.15" % "test"
 )
 
 dependencyOverrides ++=  Seq(
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.14.2",
-  "com.fasterxml.jackson.dataformat"  % "jackson-dataformat-cbor" % "2.14.2"
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.15.4",
+  "com.fasterxml.jackson.dataformat"  % "jackson-dataformat-cbor" % "2.15.4"
 )
 
 Universal / topLevelDirectory := None

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ name := "editors-picks-uploader"
 
 lazy val editorsPicksUploader = (project in file(".")).enablePlugins(JavaAppPackaging)
 
-val AwsSdkVersion = "1.12.673"
+val AwsSdkVersion = "1.12.765"
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.2",

--- a/src/main/scala/com/gu/contentapi/Config.scala
+++ b/src/main/scala/com/gu/contentapi/Config.scala
@@ -1,6 +1,6 @@
 package com.gu.contentapi
 
-import com.amazonaws.regions.{ Region, Regions }
+import com.amazonaws.regions.{ RegionUtils }
 
 object Config {
 
@@ -16,7 +16,7 @@ object Config {
 
     val region = {
       val region = sys.env.getOrElse("awsRegion", "eu-west-1")
-      Region.getRegion(Regions.fromName(region))
+      RegionUtils.getRegion(region)
     }
 
     val topicArn = sys.env.getOrElse("awsTopicArn", sys.error("Could not find awsTopicArn variable - Lambda will not run."))


### PR DESCRIPTION
## What does this change?

This will fix jackson high vulnerability, also bumps facia-json API version from v27 to v30 and aws sdk patch version.

## How to test

Will deploy on CODE and check logs
Snyk test shows no high vulnerability.

## How can we measure success?

No unusual pattern should get detected and vulnerability shouldn't exist anymore.
