### PR TITLE
Close response bodies, update scala, sbt, and sbt plugins

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,10 @@
 name: Build editors-picks-uploader
 
 on:
-  push:
-    branches: [ "**" ]
+  pull_request:
+  push: # Do not rely on `push` for PR CI - see https://github.com/guardian/mobile-apps-api/pull/2741#issuecomment-1777653733
+    branches:
+      - main # Optimal for GHA workflow caching - see https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache
   workflow_dispatch: {}
 
 jobs:

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 organization  := "com.gu"
 description   := "AWS Lambda uploading editors picks from Facia to CAPI"
 scalacOptions += "-deprecation"
-scalaVersion  := "2.13.10"
+scalaVersion  := "2.13.14"
 scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-Xfatal-warnings")
 name := "editors-picks-uploader"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.3
+sbt.version=1.10.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
-
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.10.4")
 
 addDependencyTreePlugin

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.6")
+addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.10.4")
 
 addDependencyTreePlugin
 

--- a/src/main/scala/com/gu/contentapi/models/Notification.scala
+++ b/src/main/scala/com/gu/contentapi/models/Notification.scala
@@ -4,11 +4,12 @@ import org.joda.time.DateTime
 import play.api.libs.json.JodaReads._
 import play.api.libs.json.JodaWrites._
 import play.api.libs.json.{ JsValue, Json }
+import play.api.libs.json.OFormat
 
 case class Item(id: String, content: JsValue)
 
 object Item {
-  implicit def ItemFormats = Json.format[Item]
+  implicit def ItemFormats: OFormat[Item] = Json.format[Item]
 }
 
 case class NotificationBody(
@@ -18,7 +19,7 @@ case class NotificationBody(
   item: Item)
 
 object NotificationBody {
-  implicit def NotificationBodyFormats = Json.format[NotificationBody]
+  implicit def NotificationBodyFormats: OFormat[NotificationBody] = Json.format[NotificationBody]
 }
 
 case class Notification(
@@ -29,7 +30,7 @@ case class Notification(
 
 object Notification {
 
-  implicit def NotificationFormats = Json.format[Notification]
+  implicit def NotificationFormats: OFormat[Notification] = Json.format[Notification]
 
   def create(editorsPick: EditorsPick): Notification = {
     val id = editorsPick.front

--- a/src/main/scala/com/gu/contentapi/services/Facia.scala
+++ b/src/main/scala/com/gu/contentapi/services/Facia.scala
@@ -40,9 +40,12 @@ object Facia {
     val response: Response = Http.get(s"${Config.nextGenApiUrl}$front/lite.json")
 
     if (response.code == 200) {
-      (Json.parse(response.body.byteStream) \ "collections").asOpt[JsArray]
+      val parsedResponse: Option[JsArray] = (Json.parse(response.body.byteStream) \ "collections").asOpt[JsArray]
+      response.body.close()
+      parsedResponse
     } else {
       println(s"Could not retrieve editors picks for front: $front")
+      response.body.close()
       None
     }
   }


### PR DESCRIPTION
## What does this change?

@Divs-B noticed an error [in testing another PR](https://github.com/guardian/editors-picks-uploader/pull/22#issuecomment-2329106575), so I created this PR to fix it. While here, I updated some scala and sbt versions, and updated/removed some plugins to get a passing build locally.

## How to test

- deploy this branch to CODE
- wait for the schedule to trigger the lambda (happens every 5 minutes)
- check the logs and confirm there’s no mention of responses being leaked