### PR TITLE
Keep scalatest test results on stdout

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,4 +28,4 @@ dependencyOverrides ++=  Seq(
 Universal / topLevelDirectory := None
 Universal / packageName  := normalizedName.value
 
-Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-u", sys.env.getOrElse("SBT_JUNIT_OUTPUT", "junit"))
+Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-u", sys.env.getOrElse("SBT_JUNIT_OUTPUT", "junit"), "-o")


### PR DESCRIPTION
When using -u, scalatest disables individual test results on stdout. However, some developers prefer the junit output and some prefer the stdout output: adding the -o flag keeps both.